### PR TITLE
Feature/add description and wiki

### DIFF
--- a/grove_acc_mma7660/grove_acc_mma7660.h
+++ b/grove_acc_mma7660/grove_acc_mma7660.h
@@ -32,10 +32,12 @@
 
 #include "suli2.h"
 
-//GROVE_NAME        "Grove-3Axis Digital Acc(�1.5g)"
+//GROVE_NAME        "Grove-3Axis Digital Acc(±1.5g)"
 //SKU               101020039
 //IF_TYPE           I2C
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/b/bb/3_aix_acc.jpg
+//DESCRIPTION       "This 3-Axis Digital Accelerometer(±1.5g) is based on Freescale's low power consumption module, MMA7660FC. It features up to 10,000g high shock survivability and configurable Samples per Second rate. Test Range: ±1.5g, Sensitivity: 21LSB/g"
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_3-Axis_Digital_Accelerometer(±1.5g)
 
 #define MMA7660_ADDR  (0x4c<<1)
 

--- a/grove_airquality_tp401a/grove_airquality_tp401a.h
+++ b/grove_airquality_tp401a/grove_airquality_tp401a.h
@@ -37,7 +37,8 @@
 //SKU               101020078
 //IF_TYPE           ANALOG
 //IMAGE_URL         http://www.seeedstudio.com/depot/images/product/101020078%201_02.jpg
-
+//DESCRIPTION       "This sensor is designed for comprehensive monitor over indoor air condition. It's responsive to a wide scope of harmful gases, as carbon monoxide, alcohol, acetone, thinner, formaldehyde and so on. Due to the measuring mechanism, this sensor can not output specific data to describe target gases' concentrations quantitatively. But it's still competent enough to be used in applications that require only qualitative results, like auto refresher sprayers and auto air cycling systems."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Air_Quality_Sensor
 
 class GroveAirquality
 {

--- a/grove_baro_bmp085/grove_baro_bmp085.h
+++ b/grove_baro_bmp085/grove_baro_bmp085.h
@@ -36,7 +36,8 @@
 //SKU               101020032
 //IF_TYPE           I2C
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/thumb/e/e7/Grove-Barometer.jpg/621px-Grove-Barometer.jpg
-
+//DESCRIPTION       "This Sensor features a Bosch BMP085 high-accuracy chip to detect barometric pressure and temperature. It can widely measure pressure ranging from 300hPa to 1100hPa, AKA +9000m to -500m above sea level, with a super high accuracy of 0.03hPa(0.25m) in ultra-high resolution mode."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Barometer_Sensor
 
 
 #define BMP085_ADDRESS (0x77<<1)

--- a/grove_baro_bmp280/grove_baro_bmp280.h
+++ b/grove_baro_bmp280/grove_baro_bmp280.h
@@ -36,7 +36,8 @@
 //SKU               101020192
 //IF_TYPE           I2C
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/thumb/a/a4/Bmp280.jpg/610px-Bmp280.jpg
-
+//DESCRIPTION       "This sensor is high-precision and low-power digital barometer, can be used to detect temperature and atmospheric pressure accurately. As atmospheric pressure changes with altitude, it can also detect approximate altitude of a place."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Barometer_Sensor_(BMP280)
 
 
 #define BMP280_ADDRESS   (0x77<<1)

--- a/grove_button/grove_button.h
+++ b/grove_button/grove_button.h
@@ -36,6 +36,8 @@
 //SKU               101020003
 //IF_TYPE           GPIO
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/thumb/c/ca/Button.jpg/300px-Button.jpg
+//DESCRIPTION       "Grove Button is a momentary push button. It contains one independent "momentary on/off" button. “Momentary” means that the button rebounds on its own after it is released. The button outputs a HIGH signal when pressed, and LOW when released."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Button
 
 class GroveButton
 {

--- a/grove_comp_hmc5883l/grove_comp_hmc5883l.h
+++ b/grove_comp_hmc5883l/grove_comp_hmc5883l.h
@@ -37,6 +37,8 @@
 //SKU               101020034
 //IF_TYPE           I2C
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/thumb/b/be/Axis_compass.jpg/400px-Axis_compass.jpg
+//DESCRIPTION       "This 3-axis digital compass features a low field magnetic sensing multi-chip module HMC5883L, which provides up to 1° to 2° heading accuracy. HMC5883L consists of high-resolution HMC118X series magneto-resistive sensors, as well as Honeywell developed ASIC containing amplification, automatic degaussing strap drivers, offset cancellation and 12 bit ADC."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_3-Axis_Compass_V1.0
 
 #define HMC5883L_ADDRESS (0x1E<<1)
 

--- a/grove_digital_light/grove_digital_light.h
+++ b/grove_digital_light/grove_digital_light.h
@@ -35,7 +35,8 @@
 //SKU               101020030
 //IF_TYPE           I2C
 //IMAGE_URL         http://www.seeedstudio.com/wiki/images/6/69/Digital_Light_Sensor.jpg
-
+//DESCRIPTION       "This module is based on the I2C light-to-digital converter TSL2561 to transform light intensity to a digital signal, features a selectable light spectrum range due to its dual light sensitive diodes: infrared and full spectrum."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Digital_Light_Sensor
 
 #include "suli2.h"
 

--- a/grove_dryreed_relay/grove_dryreed_relay.h
+++ b/grove_dryreed_relay/grove_dryreed_relay.h
@@ -36,7 +36,8 @@
 //SKU               103020014
 //IF_TYPE           GPIO
 //IMAGE_URL         http://www.seeedstudio.com/depot/bmz_cache/1/16a562af66ac52d6e0e19a7b6ec5588d.image.530x397.jpg
-
+//DESCRIPTION       "The module is a relay module which works through magnetizing the vibration reed via the current in the coils. Compared to electromagnetic relays, the contacts completely sealed is the biggest feature of the Dry-Reed Relay. Besides, it features simplicity in construct, compactness, fast speed and long life, which make it widely applied in many fields such as microelectronic detection, Automatic Control etc."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Dry-Reed_Relay
 
 class GroveDryReedRelay
 {

--- a/grove_el_driver/grove_el_driver.h
+++ b/grove_el_driver/grove_el_driver.h
@@ -36,7 +36,8 @@
 //SKU               105020005
 //IF_TYPE           GPIO
 //IMAGE_URL         http://www.seeedstudio.com/depot/bmz_cache/4/45c3a0b2df09759a952ae01bf5207b42.image.530x397.jpg
-
+//DESCRIPTION       "Grove - EL Driver is designed for driving EL Wires.It integrates a very small inverter to drive the EL Wire, so you can easily light up the EL Wire with just one single Grove cable."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_EL_Driver
 
 class GroveEL
 {

--- a/grove_electromagnet/grove_electromagnet.h
+++ b/grove_electromagnet/grove_electromagnet.h
@@ -36,7 +36,8 @@
 //SKU               101020073
 //IF_TYPE           GPIO
 //IMAGE_URL         http://www.seeedstudio.com/depot/bmz_cache/9/9509f6e5cb898db66420ae739bb51eb3.image.164x123.jpg
-
+//DESCRIPTION       "Grove - Electromagnet is a type of magnet in which the magnetic field is produced by electric current and it can shuck 1KG weight and hold on."
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Electromagnet
 
 class GroveElecMagnet
 {

--- a/grove_encoder/grove_encoder.h
+++ b/grove_encoder/grove_encoder.h
@@ -36,7 +36,8 @@
 //SKU               111020001
 //IF_TYPE           UART
 //IMAGE_URL         http://www.seeedstudio.com/depot/bmz_cache/0/00a3a97e35f0ede1275ea4a989e4953c.image.530x397.jpg
-
+//DESCRIPTION       "This module is an incremental rotary encoder. It encodes the rotation signal from the axis and output the signal by electronic pulse. "
+//WIKI_URL          http://www.seeedstudio.com/wiki/Grove_-_Encoder
 
 class GroveEncoder
 {


### PR DESCRIPTION
Add description and wiki to:

grove_acc_mma7660,
grove_airquality_tp401a,
grove_baro_bmp085,
grove_baro_bmp280
grove_button,
grove_comp_hmc5883l,
grove_digital_light,
grove_dryreed_relay,
grove_el_driver,
grove_electromagnet,
grove_encoder.
