### PR TITLE
From the datasheet, the LCD can display more characters

### DIFF
--- a/grove_lcd_rgb/grove_lcd_rgb.cpp
+++ b/grove_lcd_rgb/grove_lcd_rgb.cpp
@@ -151,7 +151,7 @@ size_t GroveLCDRGB::write(uint8_t C)
         return 0;
     }
 
-    if(C < 32 || C > 127) //Ignore non-printable ASCII characters. This can be modified for multilingual font.
+    if(C < 32) //Ignore non-printable control characters.
     {
         if (C=='\r')
         {


### PR DESCRIPTION
From the datasheet, Grove I2C RGB LED has capabilities to display
characters that are assigned to over 127 codes.
http://www.seeedstudio.com/wiki/images/0/03/JHD1214Y_YG_1.0.pdf
