### PR TITLE
Added Grove Driver for Cytron 13Amp DC Motor Driver - SMD Compatible

### DIFF
--- a/cytron_motor_driver_md13s/cytron_motor_driver_md13s.cpp
+++ b/cytron_motor_driver_md13s/cytron_motor_driver_md13s.cpp
@@ -1,0 +1,94 @@
+/*
+ * cytron_motor_driver_md13s.cpp
+ *
+ * Copyright (c) 2016 Cytron Technologies Sdn Bhd.
+ * Website    : www.cytron.com.my
+ * Author     : Kong Wai Weng (waiweng@cytron.com.my)
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "suli2.h"
+#include "cytron_motor_driver_md13s.h"
+
+CytronMD13S::CytronMD13S(int pintx, int pinrx)
+{
+    this->io_pwm = (PWM_T *)malloc(sizeof(PWM_T));
+    this->io_dir = (IO_T *)malloc(sizeof(IO_T));
+
+    suli_pwm_init(this->io_pwm, pintx);
+    suli_pin_init(this->io_dir, pinrx, SULI_OUTPUT);
+    
+    this->speed = 0.0;
+    
+    suli_pwm_output(this->io_pwm, 0.0);
+    suli_pin_write(this->io_dir, SULI_LOW);
+}
+
+
+
+bool CytronMD13S::write_speed(float speed)
+{
+    this->speed = speed;
+    suli_pwm_output(this->io_pwm, speed);
+    
+    return true;
+}
+
+bool CytronMD13S::read_speed(float *speed)
+{
+    *speed = this->speed;
+    
+    return true;
+}
+
+
+
+bool CytronMD13S::write_direction(int direction)
+{
+    suli_pin_write(this->io_dir, direction);
+    return true;
+}
+
+bool CytronMD13S::read_direction(int *direction)
+{
+    *direction = suli_pin_read(this->io_dir);
+    return true;
+}
+
+
+
+bool CytronMD13S::write_speed_dir(float speed, int direction)
+{
+    this->speed = speed;
+    suli_pwm_output(this->io_pwm, speed);
+    suli_pin_write(this->io_dir, direction);
+    
+    return true;
+}
+
+bool CytronMD13S::read_speed_dir(float *speed, int *direction)
+{
+    *speed = this->speed;
+    *direction = suli_pin_read(this->io_dir);
+    
+    return true;
+}

--- a/cytron_motor_driver_md13s/cytron_motor_driver_md13s.h
+++ b/cytron_motor_driver_md13s/cytron_motor_driver_md13s.h
@@ -1,0 +1,120 @@
+/*
+ * cytron_motor_driver_md13s.h
+ *
+ * Copyright (c) 2016 Cytron Technologies Sdn Bhd.
+ * Website    : www.cytron.com.my
+ * Author     : Kong Wai Weng (waiweng@cytron.com.my)
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#ifndef __CYTRON_MOTOR_DRIVER_MD13S_H__
+#define __CYTRON_MOTOR_DRIVER_MD13S_H__
+
+#include "suli2.h"
+
+//GROVE_NAME        "Cytron 13Amp DC Motor Driver - SMD Compatible (MD13S)"
+//SKU               MD13S
+//IF_TYPE           UART
+//IMAGE_URL         http://www.seeedstudio.com/wiki/images/b/b4/Generic_analog_output.png
+//DESCRIPTION       "Grove compatible DC motor driver which supports 6-30V, 30A peak and 13A continuous current."
+//WIKI_URL          https://github.com/Seeed-Studio/Grove_Drivers_for_Wio/wiki/Grove_Generic_PWM
+//ADDED_AT          "2016-08-02"
+//AUTHOR            "CYTRON"
+
+class CytronMD13S
+{
+public:
+    CytronMD13S(int pintx, int pinrx);
+
+    /**
+     * Change the motor speed. The initial speed is 0 when the module is powered on.
+     *
+     * @param speed - motor speed, 0.0~100.0
+     *
+     * @return bool
+     */
+    bool write_speed(float speed);
+
+    /**
+     * Read the motor speed. This is the PWM duty cycle and is not the actual motor speed.
+     *
+     * @param speed - motor speed, 0.0~100.0
+     *
+     * @return bool
+     */
+    bool read_speed(float *speed);
+    
+    
+    
+    /**
+     * Change the motor direction. The initial direction is 0 when the module is powered on.
+     *
+     * @param direction - motor direction, 0 or 1
+     *
+     * @return bool
+     */
+    bool write_direction(int direction);
+    
+    /**
+     * Read the motor direction.
+     *
+     * @param direction - motor direction, 0 or 1
+     *
+     * @return bool
+     */
+    bool read_direction(int *direction);
+    
+    
+    
+    /**
+     * Change the motor speed and direction together.
+     *
+     * @param speed - motor speed, 0.0~100.0
+     * @param direction - motor direction, 0 or 1
+     *
+     * @return bool
+     */
+    bool write_speed_dir(float speed, int direction);
+    
+    
+    /**
+     * Read the motor speed and direction together.
+     *
+     * @param speed - motor speed, 0.0~100.0
+     * @param direction - motor direction, 0 or 1
+     *
+     * @return bool
+     */
+    bool read_speed_dir(float *speed, int *direction);
+    
+
+
+private:
+    PWM_T *io_pwm;
+    IO_T *io_dir;
+    
+    float speed;
+};
+
+
+#endif

--- a/cytron_motor_driver_md13s/cytron_motor_driver_md13s.h
+++ b/cytron_motor_driver_md13s/cytron_motor_driver_md13s.h
@@ -35,10 +35,10 @@
 //GROVE_NAME        "Cytron 13Amp DC Motor Driver - SMD Compatible (MD13S)"
 //SKU               MD13S
 //IF_TYPE           UART
-//IMAGE_URL         http://www.seeedstudio.com/wiki/images/b/b4/Generic_analog_output.png
+//IMAGE_URL         http://www.cytron.com.my/image/cache/data/products/MD13S/MD13S-800x800.jpg
 //DESCRIPTION       "Grove compatible DC motor driver which supports 6-30V, 30A peak and 13A continuous current."
-//WIKI_URL          https://github.com/Seeed-Studio/Grove_Drivers_for_Wio/wiki/Grove_Generic_PWM
-//ADDED_AT          "2016-08-02"
+//WIKI_URL          https://docs.google.com/document/d/1icu1GVDxZhUn3ADSUc3JknNcmUMdPcsnJ4MhxOPRo-I/view
+//ADDED_AT          "2016-08-10"
 //AUTHOR            "CYTRON"
 
 class CytronMD13S


### PR DESCRIPTION
I would like to add the Grove Driver for Cytron's Grove-compaible 13Amp DC motor driver (MD13S).
http://www.cytron.com.my/p-MD13S

For your information, the MD13S uses 2 Grove pins. One GPIO for motor direction control and one PWM pin for motor speed control.
However, I noticed that most of the Seeed's Grove modules are using only 1 GPIO pin.
Thus, I do have several questions on how to add the Grove driver for the MD13S.
1. What should I put for the //IF_TYPE field? I'm using "UART" even thought it's actually using a PWM and GPIO pin. Is there any other way so that the class constructor can accept 2 parameters for pin number?
2. We do not have our own private server. Is it possible to test out the code on our own?
