### PR TITLE
Fix wrong method name for rotate display

### DIFF
--- a/grove_oled_12864/grove_oled_12864.h
+++ b/grove_oled_12864/grove_oled_12864.h
@@ -187,7 +187,7 @@ public:
     *
     * @return bool
     */
-    bool write_inverse_display(uint8_t rotate_or_not);
+    bool write_rotate_display(uint8_t rotate_or_not);
 
     char *get_last_error() { return error_desc; };
 


### PR DESCRIPTION
Must have missed this during the merge. The new method in the header file was using the incorrect name.